### PR TITLE
TP12736 - remove unused travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.2
-before_install: gem install bundler -v 2.0.1


### PR DESCRIPTION
I didn't change the version and didn't release this to rubygems, since it wasn't done since the initial version `0.1.0` and also this only affects CI/CD.